### PR TITLE
fix wall recipe conflict with certain mods

### DIFF
--- a/source/libs/recipe.lua
+++ b/source/libs/recipe.lua
@@ -1,7 +1,7 @@
 
 function ChangeRecipe(Name, Ingredient1, Ingredient2, Amount)
 	for k, v in pairs(data.raw["recipe"][Name].ingredients) do
-		if v[1] == Ingredient1 then table.remove(data.raw["recipe"][Name].ingredients, k) end
+		if v[1] == Ingredient1 or v["name"] == Ingredient1 then table.remove(data.raw["recipe"][Name].ingredients, k) end
 	end
 	table.insert(data.raw["recipe"][Name].ingredients,{Ingredient2, Amount})
 end


### PR DESCRIPTION
I'm not sure which mod is the culprit, but some mod changes the item table structure from array indexes to named indexes which breaks ChangeRecipe. This results in the recipe requiring two different sets of the same item which does not play well with assemblers.

The issue can be resolved by adding a conditional or to check for the named field.